### PR TITLE
Update packages, add typings to package.json, update types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2018-08-09
+### Added
+- Reference to index.d.ts file in package.json
+### Changed
+- Return type of `withSpinner` to `React.ComponentType`
+- Type of `error/spinnerComponent` props to `React.ComponentType`
+- Use `window.setTimeout` instead of `setTimeout` due to typing mismatch
+- Move React/ReactDOM to peerDependencies
+- Update enzyme, recompose and ramda packages
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.0",
   "description": "",
   "main": "dist/src/index.js",
+  "types": "",
   "scripts": {
     "build": "tscomp build",
     "watch": "tscomp watch",
@@ -13,10 +14,15 @@
   "author": "Beanloop AB",
   "license": "MIT",
   "devDependencies": {
+    "@types/cheerio": "^0.22.8",
     "@types/jest": "^19.2.3",
+    "@types/ramda": "^0.25.36",
     "@types/react": "^16.4.8",
-    "enzyme": "^2.7.1",
-    "enzyme-to-json": "^1.5.0",
+    "@types/recompose": "^0.26.4",
+    "enzyme": "^3.4.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-adapter-react-16.3": "^1.0.0",
+    "enzyme-to-json": "^3.3.4",
     "jsdom": "^9.12.0",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
@@ -24,14 +30,15 @@
     "react-dom": "^16.4.2",
     "tscomp": "^0.9.1",
     "tslint": "^4.0.2",
-    "tslint-config-beanloop": "^0.1.0"
+    "tslint-config-beanloop": "^0.1.0",
+    "typescript": "^3.0.1"
   },
   "dependencies": {
     "ramda": "^0.23.0",
     "recompose": "^0.22.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.6.2",
+    "react": "^15.0.0 || ^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "description": "",
   "main": "dist/src/index.js",
-  "types": "",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tscomp build",
     "watch": "tscomp watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-with-spinner",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,20 +14,24 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^19.2.3",
+    "@types/react": "^16.4.8",
     "enzyme": "^2.7.1",
     "enzyme-to-json": "^1.5.0",
     "jsdom": "^9.12.0",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2",
     "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^16.4.2",
     "tscomp": "^0.9.1",
     "tslint": "^4.0.2",
     "tslint-config-beanloop": "^0.1.0"
   },
   "dependencies": {
-    "@types/react": "^15.0.16",
-    "prop-types": "^15.5.8",
     "ramda": "^0.23.0",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
     "recompose": "^0.22.0"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0",
+    "prop-types": "^15.6.2"
   }
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -5,6 +5,7 @@ import {mount, shallow} from 'enzyme'
 import toJson from 'enzyme-to-json'
 import * as React from 'react'
 import compose from 'recompose/compose'
+import defaultProps from 'recompose/defaultProps'
 import {withSpinner} from './index'
 
 const Loading = () => <span>Loading...</span>
@@ -12,8 +13,8 @@ jest.useFakeTimers()
 
 describe('withSpinner', () => {
   it('should render spinner if loading is true', () => {
-    const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: true}} />,
+    const Component = compose<any, {}>(
+      defaultProps({data: {loading: true}}),
       withSpinner({spinnerComponent: Loading}),
     )(() => <div></div>)
 
@@ -29,8 +30,8 @@ describe('withSpinner', () => {
   })
 
   it('should not render spinner if loading is false', () => {
-    const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: false}} />,
+    const Component = compose<any, {}>(
+      defaultProps({data: {loading: false}}),
       withSpinner({spinnerComponent: Loading}),
     )(({data}) => <div>loading: {data.loading.toString()}</div>)
 
@@ -43,7 +44,7 @@ describe('withSpinner', () => {
   it('should render spinner in 100 ms and after render component', () => {
     const DisplayComponent = ({data}) => <div>loading: {data.loading.toString()}, item: {data.item.id}</div>
 
-    const Component = compose(
+    const Component = compose<any, {}>(
       WrappedComponent => class extends React.Component<any, any> {
         state = {loading: true, item: null}
 
@@ -61,7 +62,7 @@ describe('withSpinner', () => {
       withSpinner({spinnerComponent: Loading}),
     )(DisplayComponent)
 
-    const wrapper = mount(<Component />)
+    let wrapper = mount(<Component />)
 
     // Should not display a Spinner
     expect(wrapper.html()).toBeNull()
@@ -69,11 +70,13 @@ describe('withSpinner', () => {
     // Run timer to 100 ms since withSpinner timeout defaults to 100 ms
     jest.runTimersToTime(100)
     // ProgressBar should now be found
+    wrapper = wrapper.update()
     expect(wrapper.find(Loading)).toHaveLength(1)
     expect(wrapper.find(DisplayComponent)).toHaveLength(0)
 
     // Run timer to 1000 ms for our own timeout
     jest.runTimersToTime(1000)
+    wrapper = wrapper.update()
     // DisplayComponent should be found
     expect(wrapper.find(DisplayComponent)).toHaveLength(1)
     expect(wrapper.find(Loading)).toHaveLength(0)
@@ -85,13 +88,12 @@ describe('withSpinner', () => {
     const Loading = () => <span>Loading...</span>
 
     const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: true}} />,
+      defaultProps({data: {loading: true}}),
       withSpinner({spinnerComponent: Loading}),
     )(null)
 
     const wrapper = shallow(<Component />).first().shallow()
     jest.runTimersToTime(100)
-    wrapper.update()
 
     expect(toJson(wrapper)).toMatchSnapshot()
   })
@@ -99,8 +101,8 @@ describe('withSpinner', () => {
   it('should ignore errors if handleError is false', () => {
     const DisplayComponent = ({data}) => <div>loading: {data.loading.toString()}, item: {data.item.id}</div>
 
-    const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: false, error: true}} />,
+    const Component = compose<any, {}>(
+      defaultProps({data: {loading: false, error: true}}),
       withSpinner({spinnerComponent: Loading, handleError: false}),
     )(DisplayComponent)
 
@@ -114,7 +116,7 @@ describe('withSpinner', () => {
     const ErrorComponent = () => <span>An unknown error occured...</span>
 
     const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: false, error: true}} />,
+      defaultProps({data: {loading: false, error: true}}),
       withSpinner({spinnerComponent: Loading, errorComponent: ErrorComponent}),
     )(null)
 
@@ -128,8 +130,8 @@ describe('withSpinner', () => {
   it('should delay rendering of spinnerComponent the timeout that is passed', () => {
     const DisplayComponent = ({data}) => <div>loading: {data.loading.toString()}, item: {data.item.id}</div>
 
-    const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: true}} />,
+    const Component = compose<any, {}>(
+      defaultProps({data: {loading: true}}),
       withSpinner({spinnerComponent: Loading, timeout: 500}),
     )(DisplayComponent)
 
@@ -141,7 +143,7 @@ describe('withSpinner', () => {
 
     // Run timer over our timeout
     jest.runTimersToTime(600)
-    expect(wrapper.first().shallow().node).toEqual(Loading())
+    expect(wrapper.first().shallow().getElement()).toEqual(Loading())
   })
 
   it('should not render errorComponent if skipErrors returns true', () => {
@@ -151,8 +153,8 @@ describe('withSpinner', () => {
       Validation error occured on field: {error.validationError.field} with message: {error.validationError.message}
     </div>
 
-    const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: false, error: validationError}} />,
+    const Component = compose<any, {}>(
+      defaultProps({data: {loading: false, error: validationError}}),
       withSpinner(({spinnerComponent: Loading,
         errorComponent: ErrorComponent,
         skipErrors: data => data.error.validationError && data.error.validationError.field === 'password'
@@ -169,7 +171,7 @@ describe('withSpinner', () => {
   it('should support custom loading property', () => {
     const DisplayComponent = ({result}) => <div>loading: {result.loading.toString()}, item: {result.item.id}</div>
 
-    const Component = compose(
+    const Component = compose<any, {}>(
       WrappedComponent => class extends React.Component<any, any> {
         state = {loading: true, item: null}
 
@@ -187,19 +189,21 @@ describe('withSpinner', () => {
       withSpinner({spinnerComponent: Loading, prop: 'result'}),
     )(DisplayComponent)
 
-    const wrapper = mount(<Component />)
+    let wrapper = mount(<Component />)
 
     // Should not display a Spinner
     expect(wrapper.html()).toBeNull()
 
     // Run timer to 100 ms since withSpinner timeout defaults to 100 ms
     jest.runTimersToTime(100)
+    wrapper = wrapper.update()
     // ProgressBar should now be found
     expect(wrapper.find(Loading)).toHaveLength(1)
     expect(wrapper.find(DisplayComponent)).toHaveLength(0)
 
     // Run timer to 1000 ms for our own timeout
     jest.runTimersToTime(1000)
+    wrapper = wrapper.update()
     // DisplayComponent should be found
     expect(wrapper.find(DisplayComponent)).toHaveLength(1)
     expect(wrapper.find(Loading)).toHaveLength(0)
@@ -208,7 +212,7 @@ describe('withSpinner', () => {
   it('should support custom nested loading property', () => {
     const DisplayComponent = ({result}) => <div>loading: {result.nested.loading.toString()}, item: {result.nested.item && result.nested.item.id}</div>
 
-    const Component = compose(
+    const Component = compose<any, {}>(
       WrappedComponent => class extends React.Component<any, any> {
         state = {loading: true, item: null}
 
@@ -228,19 +232,21 @@ describe('withSpinner', () => {
       // withSpinner(),
     )(DisplayComponent)
 
-    const wrapper = mount(<Component />)
+    let wrapper = mount(<Component />)
 
     // Should not display a Spinner
     expect(wrapper.html()).toBeNull()
 
     // Run timer to 100 ms since withSpinner timeout defaults to 100 ms
     jest.runTimersToTime(100)
+    wrapper = wrapper.update()
     // ProgressBar should now be found
     expect(wrapper.find(Loading)).toHaveLength(1)
     expect(wrapper.find(DisplayComponent)).toHaveLength(0)
 
     // Run timer to 1000 ms for our own timeout
     jest.runTimersToTime(1000)
+    wrapper = wrapper.update()
     // DisplayComponent should be found
     expect(wrapper.find(DisplayComponent)).toHaveLength(1)
     expect(wrapper.find(Loading)).toHaveLength(0)
@@ -251,7 +257,7 @@ describe('withSpinner', () => {
     const EmptyComponent = () => <span>No data...</span>
 
     const Component = compose(
-      WrappedComponent => props => <WrappedComponent {...props} data={{loading: false, value: {}}} />,
+      defaultProps({data: {loading: false, value: {}}}),
       withSpinner({spinnerComponent: Loading, emptyComponent: EmptyComponent, prop: ['data', 'value']}),
     )(null)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,7 +101,7 @@ export const withSpinner = ({
       if (this.state.showSpinner) return <Spinner {...spinnerProps} {...this.props} />
 
       if (this.timeout === null) {
-        this.timeout = setTimeout(() => {
+        this.timeout = window.setTimeout(() => {
           this.setState({showSpinner: true})
         }, timeout)
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,7 @@ export const withSpinner = ({
   errorComponent: ErrorComponent = null,
   spinnerComponent: Spinner,
   emptyComponent: EmptyComponent = null,
-}: Properties): any => WrappedComponent =>
+}: Properties) => (WrappedComponent: React.ComponentType): React.ComponentType =>
   class extends Component<Properties, {showSpinner: boolean}> {
     static displayName = wrapDisplayName(WrappedComponent, 'withSpinner')
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ export type Properties = {
    * Component to be rendered if an error occurs.
    * Defaults to null.
    */
-  errorComponent?: ReactType
+  errorComponent?: React.ComponentType
   /**
    * If the HOC should take partial data into account.
    * Defaults to false.
@@ -35,7 +35,7 @@ export type Properties = {
    * Component that should be rendered while loading.
    * Defaults to a React Toolbox ProgressBar component.
    */
-  spinnerComponent: ReactType
+  spinnerComponent: React.ComponentType
   /**
    * Extra props that should be passed to the [spinnerComponent].
    */

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,4 +1,8 @@
+import {configure} from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16.3'
 import {jsdom} from 'jsdom'
+
+configure({adapter: new Adapter()})
 
 declare const global
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,9 +31,18 @@
   version "10.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
 
-"@types/react@^15.0.16":
-  version "15.6.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.18.tgz#1780f1a2848c49bf18b81bc71766e6358c2d6901"
+"@types/prop-types@*":
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.4.tgz#9e6199bad131786e24c2baa2a82705a02139fbf8"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.4.8":
+  version "16.4.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.8.tgz#ff0440429783df0927bdcd430fa1225f7c08cf36"
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 Base64@~0.2.0:
   version "0.2.1"
@@ -1711,14 +1720,6 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-react-class@^15.6.0:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.0.tgz#8254774ab4786b8c5b3cf4dfba66ce563932c252"
@@ -1895,6 +1896,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -2596,7 +2601,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -6288,7 +6293,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6411,14 +6416,14 @@ react-addons-test-utils@^15.4.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
 
-react-dom@^15.4.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+react-dom@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-test-renderer@^15.4.2:
   version "15.6.2"
@@ -6427,15 +6432,14 @@ react-test-renderer@^15.4.2:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react@^15.4.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
+react@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-cache@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@types/cheerio@^0.22.8":
+  version "0.22.8"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.8.tgz#5702f74f78b73e13f1eb1bd435c2c9de61a250d4"
+
 "@types/estree@0.0.38":
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
@@ -37,12 +41,22 @@
   dependencies:
     "@types/react" "*"
 
+"@types/ramda@^0.25.36":
+  version "0.25.36"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.36.tgz#1ddaf3211c7cd7046fcaefe68c713469ccfc9504"
+
 "@types/react@*", "@types/react@^16.4.8":
   version "16.4.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.8.tgz#ff0440429783df0927bdcd430fa1225f7c08cf36"
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/recompose@^0.26.4":
+  version "0.26.4"
+  resolved "https://registry.yarnpkg.com/@types/recompose/-/recompose-0.26.4.tgz#93dd6c4e28857cd799e9a807a470f66a40c49c3f"
+  dependencies:
+    "@types/react" "*"
 
 Base64@~0.2.0:
   version "0.2.1"
@@ -293,6 +307,14 @@ array-unique@^0.2.1:
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+
+array.prototype.flat@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
 
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
@@ -1400,26 +1422,16 @@ change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
-cheerio@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
   dependencies:
     css-select "~1.2.0"
     dom-serializer "~0.1.0"
     entities "~1.1.1"
     htmlparser2 "^3.9.1"
-    lodash.assignin "^4.0.9"
-    lodash.bind "^4.1.4"
-    lodash.defaults "^4.0.1"
-    lodash.filter "^4.4.0"
-    lodash.flatten "^4.2.0"
-    lodash.foreach "^4.3.0"
-    lodash.map "^4.4.0"
-    lodash.merge "^4.4.0"
-    lodash.pick "^4.2.1"
-    lodash.reduce "^4.4.0"
-    lodash.reject "^4.4.0"
-    lodash.some "^4.4.0"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^1.0.0:
   version "1.7.0"
@@ -1558,6 +1570,10 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@^1.0.3, colors@^1.1.2:
   version "1.3.0"
@@ -2069,6 +2085,10 @@ diff@^3.0.1, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
 dom-converter@~0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
@@ -2228,32 +2248,66 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-to-json@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.6.0.tgz#9d9bba706e8b500c673b7a4fa9ff7ce57b8b9254"
+enzyme-adapter-react-16.3@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16.3/-/enzyme-adapter-react-16.3-1.0.0.tgz#d3992301aba46c8cceab21c1d201e85f01c93bfc"
   dependencies:
-    lodash.filter "^4.6.0"
-    lodash.isnil "^4.0.0"
-    lodash.isplainobject "^4.0.6"
-    lodash.omitby "^4.6.0"
-    lodash.range "^3.2.0"
-    object-values "^1.0.0"
-    object.entries "^1.0.4"
+    enzyme-adapter-utils "^1.5.0"
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    object.values "^1.0.4"
+    prop-types "^15.6.2"
+    react-is "^16.4.1"
+    react-reconciler "^0.7.0"
+    react-test-renderer "~16.3.0-0"
 
-enzyme@^2.7.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.9.1.tgz#07d5ce691241240fb817bf2c4b18d6e530240df6"
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
   dependencies:
-    cheerio "^0.22.0"
-    function.prototype.name "^1.0.0"
+    enzyme-adapter-utils "^1.3.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.3.0, enzyme-adapter-utils@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.5.0.tgz#a020ab3ae79bb1c85e1d51f48f35e995e0eed810"
+  dependencies:
+    function.prototype.name "^1.1.0"
+    object.assign "^4.1.0"
+    prop-types "^15.6.2"
+
+enzyme-to-json@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz#67c6040e931182f183418af2eb9f4323258aa77f"
+  dependencies:
+    lodash "^4.17.4"
+
+enzyme@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.4.0.tgz#085c66fe647d8c9c4becd1fee3042c040cda88a6"
+  dependencies:
+    array.prototype.flat "^1.2.1"
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.1.0"
+    has "^1.0.3"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.4"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
     is-subset "^0.1.1"
     lodash "^4.17.4"
+    object-inspect "^1.6.0"
     object-is "^1.0.1"
-    object.assign "^4.0.4"
+    object.assign "^4.1.0"
     object.entries "^1.0.4"
     object.values "^1.0.4"
-    prop-types "^15.5.10"
-    uuid "^3.0.1"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -2271,7 +2325,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.6.1:
+es-abstract@^1.10.0, es-abstract@^1.6.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
@@ -2846,7 +2900,7 @@ function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
-function.prototype.name@^1.0.0:
+function.prototype.name@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
   dependencies:
@@ -3342,7 +3396,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
+has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
@@ -3667,6 +3721,10 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -3677,7 +3735,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1, is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
@@ -3792,6 +3850,10 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3863,6 +3925,10 @@ is-retry-allowed@^1.0.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
 
 is-subset@^0.1.1:
   version "0.1.1"
@@ -4588,14 +4654,6 @@ lodash.assign@^4.0.0, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
-lodash.assignin@^4.0.9:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
-
-lodash.bind@^4.1.4:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
-
 lodash.camelcase@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz#932c8b87f8a4377897c67197533282f97aeac298"
@@ -4611,10 +4669,6 @@ lodash.deburr@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-3.2.0.tgz#6da8f54334a366a7cf4c4c76ef8d80aa1b365ed5"
   dependencies:
     lodash._root "^3.0.0"
-
-lodash.defaults@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
 lodash.defaults@~2.4.1:
   version "2.4.1"
@@ -4637,17 +4691,9 @@ lodash.escape@~2.4.1:
     lodash._reunescapedhtml "~2.4.1"
     lodash.keys "~2.4.1"
 
-lodash.filter@^4.4.0, lodash.filter@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-
-lodash.flatten@^4.2.0:
+lodash.flattendeep@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-
-lodash.foreach@^4.3.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -4661,19 +4707,11 @@ lodash.isequal@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-lodash.isnil@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
-
 lodash.isobject@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
   dependencies:
     lodash._objecttypes "~2.4.1"
-
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -4691,53 +4729,21 @@ lodash.keys@~2.4.1:
     lodash._shimkeys "~2.4.1"
     lodash.isobject "~2.4.1"
 
-lodash.map@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.merge@^4.4.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
 lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
-lodash.omitby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
-
-lodash.pick@^4.2.1:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
 lodash.pickby@^4.0.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
-lodash.range@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
-
-lodash.reduce@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
-
-lodash.reject@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
-
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.some@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
 lodash.template@^2.4.1:
   version "2.4.1"
@@ -4795,7 +4801,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5086,6 +5092,10 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -5133,6 +5143,16 @@ ncname@1.0.x:
 ncp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+
+nearley@^2.7.10:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.15.0.tgz#d1ff5406a58064615fe6eafb429cf06fbb1b7eab"
+  dependencies:
+    moo "^0.4.3"
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 needle@^2.2.1:
   version "2.2.1"
@@ -5264,6 +5284,13 @@ node-sass@^4.5.0:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
+
 "nopt@2 || 3":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -5369,6 +5396,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
@@ -5377,17 +5408,13 @@ object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
-object-values@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/object-values/-/object-values-1.0.0.tgz#72af839630119e5b98c3b02bb8c27e3237158105"
-
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4:
+object.assign@^4.0.4, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
@@ -5623,6 +5650,12 @@ parse-passwd@^1.0.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -6293,7 +6326,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6378,9 +6411,26 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
 ramda@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -6425,12 +6475,43 @@ react-dom@^16.4.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-is@^16.3.2, react-is@^16.4.1, react-is@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
+
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-test-renderer@^15.4.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
+
+react-test-renderer@^16.0.0-0:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.2.tgz#4e03eca9359bb3210d4373f7547d1364218ef74e"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.2"
+
+react-test-renderer@~16.3.0-0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
 
 react@^16.4.2:
   version "16.4.2"
@@ -6786,6 +6867,13 @@ rollup@^0.58.2:
   dependencies:
     "@types/estree" "0.0.38"
     "@types/node" "*"
+
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
 
 rsvp@^3.0.13, rsvp@^3.0.18:
   version "3.6.2"
@@ -7780,6 +7868,10 @@ typescript@^2.2.1:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+
 ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
@@ -7809,6 +7901,10 @@ uglify-to-browserify@~1.0.0:
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR does not add/remove any features, just upgrades tooling/types.

What has been done?  
- update to latest React/ReactDOM packages
- move React/ReactDOM (and some other packages such as @types/*) to devDependencies.
- update Enzyme and update tests to work with it
- move React/ReactDOM to peerDependencies (they should be supplied by the consumer so we don't get multiple react versions)
- change `setTimeout -> window.setTimeout`. Sometimes Typescript will infer the return type to `NodeJS.Timer` instead of `number` if we just use it off the global object
- update type of `spinner/errorComponent` to `React.ReactType`. This means we can only send `React.ComponentClass | React.StatelessComponent`. The former also lets us send strings (I dont think we want that?)
- add return type `React.ComponentType` instead of any to `withSpinner` HOC
- add reference to the `index.d.ts` typing file in package.json so consumers get a typed function